### PR TITLE
Update Lecture 4

### DIFF
--- a/Lecture4.tex
+++ b/Lecture4.tex
@@ -1,5 +1,5 @@
 
-In the previous lectures we considered multi-stage decision problems for \emph{deterministic} systems. In many problems of interest, the system dynamics also involves \emph{randomness}, which leads us to stochastic decision problems. In this lecture we introduce the basic model of Markov Decision Processes, which will be considered is the rest of the course.
+In the previous lectures we considered multi-stage decision problems for \emph{deterministic} systems. In many problems of interest, the system dynamics also involve \emph{randomness}, which leads us to stochastic decision problems. In this chapter we introduce the basic model of Markov Decision Processes, which will be considered is the rest of the course.
 %Contents:
 %4.1  Markov Chains (Reminder)
 %4.2  Controlled Markov Chains
@@ -16,11 +16,11 @@ A Markov chain $\{ {X_t},\;t = 0,1,2, \ldots \} $, with ${X_t} \in X$, is a disc
 We focus on time-homogeneous Markov chains, where
 \[{\cal P}({X_{t + 1}} = j|{X_t} = i) = {\cal P}({X_1} = j|{X_0} = i) \buildrel \Delta \over = {p_{ij}}.\]
 The ${p_{ij}}$'s  are the transition probabilities, which satisfy
-${p_{ij}} \ge 0,\;\;\;\sum\nolimits_{i \in X} {{p_{ij}} = 1\;\;\forall j} $.
+${p_{ij}} \ge 0,\;\;\;\sum\nolimits_{j \in X} {{p_{ij}} = 1\;\;\forall i} $.
 The matrix $P = ({p_{ij}})$ is the transition matrix.
 
-Given the initial distribution ${p_0}$ of ${X_0}$, namely $p({X_0} = i) = {p_0}(i)$, we obtain the finite-dimensional distributions:
-\[{\cal P}({X_0} = {i_0}, \ldots ,{X_t} = {i_t}) = {p_0}(i){p_{{i_0}{i_1}}} \cdot  \ldots  \cdot {p_{{i_{t - 1}}{i_t}}}.\]
+Given the initial distribution ${p_0}$ of ${X_0}$, namely $p({X_0} = i_0) = {p_0}(i_0)$, we obtain the finite-dimensional distributions:
+\[{\cal P}({X_0} = {i_0}, \ldots ,{X_t} = {i_t}) = {p_0}(i_0){p_{{i_0}{i_1}}} \cdot  \ldots  \cdot {p_{{i_{t - 1}}{i_t}}}.\]
 
 Define $p_{ij}^{(m)} = {\cal P}({X_m} = j|{X_0} = i),$ the m-step transition probabilities.  It is easy to verify that $p_{ij}^{(m)} = {[{P^m}]_{ij}}$  (here ${P^m}$ is the m-th power of the matrix $P$).
 
@@ -30,7 +30,7 @@ Define $p_{ij}^{(m)} = {\cal P}({X_m} = j|{X_0} = i),$ the m-step transition pro
 \item $i$ and $j$ are communicating states (or communicate) if $i \to j$ and $j \to i$.
 \item A communicating class (or just class) is a maximal collection of states that communicate.
 \item The Markov chain is irreducible if all states belong to a single class (i.e., all states communicate with each other).
-\item State $i$ is periodic with period $d \ge 2$ if  $p_{ii}^{(m)} = 0$ for $m \ne \ell d$ and  $p_{ii}^{(m)} > 0$ for $m = \ell d$, $\ell  = 1,2, \ldots $.   Periodicity is a class property: all states in the same class have the same period.
+\item State $i$ is periodic with period $d \ge 2$ if  $p_{ii}^{(m)} = 0$ for $m \ne \ell d$ and  $p_{ii}^{(m)} > 0$ for $m = \ell d$, $\ell = \{ 1,2, \ldots \}$. Periodicity is a class property: all states in the same class have the same period.
 \end{itemize}
 
 \paragraph{Recurrence:}
@@ -53,7 +53,7 @@ Clearly, if ${X_t} \sim \pi $ then ${X_{t + 1}} \sim \pi $. If ${X_0} \sim \pi $
 \item All states are \textbf{positive recurrent}
 \item There exists a \textbf{unique stationary distribution} ${\pi ^*}$
 \item \textbf{Convergence} to the stationary distribution: ${\lim _{t \to \infty }}p_{ij}^{(t)} = {\pi _j}\quad (\forall j)$
-\item \textbf{Ergodicity}: For any finite $f$: ${\lim _{t \to \infty }}\frac{1}{t}\sum\nolimits_{s = 0}^{t - 1} {f({X_s}) = \sum\nolimits_i {\pi (i)f(i) \buildrel \Delta \over = } } \,\pi  \cdot f.$
+\item \textbf{Ergodicity}: For any finite $f$: ${\lim _{t \to \infty }}\frac{1}{t}\sum\nolimits_{s = 0}^{t - 1} {f({X_s}) = \sum\nolimits_i {\pi_i f(i) \buildrel \Delta \over = } } \,\pi  \cdot f.$
 \end{enumerate}
 \end{theorem}
 
@@ -70,7 +70,7 @@ Let $({X_t})$ be an irreducible and a-periodic Markov chain over a countable sta
 
 \paragraph{Reversible Markov chains:} Suppose there exists a probability vector $\pi  = ({\pi _i})$ so that
                                                 \begin{equation}\label{eq:DB}
-                                                {\pi _i}{p_{ij}} = {\pi _j}{p_{ji}},\quad \quad i,j \in X.
+                                                {\pi _i}{p_{ij}} = {\pi _j}{p_{ji}},\quad \quad \forall i,j \in X.
                                                 \end{equation}
 It is then easy to verify by direct summation that $\pi $ is an invariant distribution for the Markov chain defined by $({p_{ij}})$.
 The equations \eqref{eq:DB} are called the \emph{detailed balance equations}. A Markov chain that satisfies these equations is called reversible.
@@ -88,7 +88,7 @@ Suppose further that each ${S_t}$ is a Bernoulli RV with parameter $q$, namely $
 0&:&{{\rm{otherwise}}}
 \end{array}} \right.\]
  Denote $\lambda  = p(1 - q)$, $\mu  = (1 - p)q$, and $\rho  = \lambda /\mu $.   The detailed balance equations for this case are:
-\[{\pi _i}\lambda  = {\pi _{i + 1}}\mu ,\quad \quad i \ge 0\]
+\[{\pi _i}\lambda  = {\pi _{i + 1}}\mu ,\quad \quad \forall i \ge 0\]
 These equations have a solution with $\sum {_i{\pi _i} = 1}$ if and only if $\rho  < 1$. The solution is ${\pi _i} = {\pi _0}{\rho ^i}$, with ${\pi _0} = 1 - \rho $. This is therefore the stationary distribution of this queue.
 
 
@@ -163,7 +163,7 @@ p(s'|s = 1,a = 2) = \left\{ {\begin{array}{*{20}{c}}
 The stochastic state dynamics can be equivalently defined in terms of a state equation of the form
                                                    \[{s_{t + 1}} = {f_t}({s_t},{a_t},{w_t}),\]
 where ${w_t}$ is a random variable.
- 	If  ${({w_t})_{t \ge 0}}$ is a sequence of independent RVs, and further each ${w_t}$ is independent of the "past"  $({s_{t - 1}},{a_{t - 1}}, \ldots {s_0})$, then ${({s_t},{a_t})_{t \ge 0}}$ is a controlled Markov process.
+ 	If  ${({w_t})_{t \ge 0}}$ is a sequence of independent RVs, and further each ${w_t}$ is independent of the "past"  $({s_{t - 1}},{a_{t - 1}}, \ldots, {s_0})$, then ${({s_t},{a_t})_{t \ge 0}}$ is a controlled Markov process.
  	For example, the state transition law of the last example can be written in this way, using
                   ${w_t} \in \{ 4,5,6\} $,  with  ${p_w}(4) = 0.3,\;{p_w}(5) = 0.2,\;{p_w}(6) = 0.5$
 and, for ${s_t} = 1$:
@@ -228,12 +228,12 @@ Our general goal is to maximize the cumulative return:
                                              \[\sum\limits_{t = 0}^T {{R_t}}  = \sum\limits_{t = 0}^{T - 1} {{r_t}({s_t},{a_t}) + {r_T}({s_T})} .\]
 However, since the system is stochastic, the cumulative return will generally be random, and we need to specify in which sense to maximize it.
 A natural first option is to consider the expected value of the return. That is, define:
-\[J_T^\pi (s) = {E^\pi }(\sum\limits_{t = 0}^T {{R_t}} |{s_0} = s) \equiv {E^{\pi ,s}}(\sum\limits_{t = 0}^T {{R_t}} )\]
- Here $\pi $ is the control policy as defined above, and $s$ denotes the initial state. Hence,  $J_T^\pi (s)$ is the expected cumulative return under the control policy $\pi $.  Our goal is to find an optimal control policy that maximized $J_T^\pi (s)$.
+\[J_T^\pi (s) = {E^\pi }\left(\sum\limits_{t = 0}^T {{R_t}} |{s_0} = s\right) \equiv {E^{\pi ,s}}\left(\sum\limits_{t = 0}^T {{R_t}} \right)\]
+ Here $\pi $ is the control policy as defined above, and $s$ denotes the initial state. Hence,  $J_T^\pi (s)$ is the expected cumulative return under the control policy $\pi $.  Our goal is to find an optimal control policy that maximizes $J_T^\pi (s)$.
 
 \paragraph{Remarks:}
 \begin{enumerate}
-  \item Dependence on the next state:  In some problems, the obtained reward may depend on the next state as well: ${R_t} = {\tilde r_t}({s_t},{a_t},{s_{t + 1}})$.  For control purposes, when we only consider the expected value of the reward, we can reduce this reward function to the usual one by defining
+  \item Dependence on the next state:  In some problems, the obtained reward may depend on the next state as well: ${R_t} = {\tilde r_t}({s_t},{a_t},{s_{t + 1}})$.  For control purposes, when we only consider the expected value of the reward, we can reduce this reward function to the usual one by defining:
 \[{r_t}(s,a) \buildrel \Delta \over = E({R_t}|{s_t} = s,{a_t} = a) \equiv \sum\nolimits_{s' \in S} {p(s'|s,a){{\tilde r}_t}(} s,a,s')\]
   \item Random rewards:  The reward ${R_t}$ may also be random, namely a random variable whose distribution depends on $({s_t},{a_t})$.  This can also be reduced to our standard model for planning purposes by looking at the expected value of ${R_t}$, namely \[{r_t}(s,a) = E({R_t}|{s_t} = s,{a_t} = a).\]
   \item Risk-sensitive criteria: The expected cumulative return is by far the most common goal for planning. However it is not the only one possible. For example, one may consider the following risk-sensitive  return function:
@@ -242,15 +242,15 @@ For $\lambda  > 0$, the exponent gives higher weight to high rewards, and the op
 \end{enumerate}
 
 \subsection{Infinite Horizon Problems}
-We next consider planning problems that extend to an unlimited time horizon, $t = 0,1,2, \ldots $. Such planning problems arise when the system in question is expected to operate for a long time, or a large number of steps, possibly with no specific "closing" time.
+We next consider planning problems that extend to an unlimited time horizon, $t = \{0,1,2, \ldots \}$. Such planning problems arise when the system in question is expected to operate for a long time, or a large number of steps, possibly with no specific "closing" time.
 Infinite horizon problems are most often defined for stationary problems. In that case, they enjoy the important advantage that optimal policies can be found among the class of stationary policies.  We will restrict attention here to stationary models.
 As before, we have the running reward function $r(s,a)$, which extends to all $t \ge 0$. The reward obtained at stage $t$ is  ${R_t} = r({s_t},{a_t})$.
 
 \paragraph{Discounted return:} The most common performance criterion for infinite horizon problems is the expected discounted return:
-\[J_\alpha ^\pi (s) = {E^\pi }(\sum\limits_{t = 0}^\infty  {{\alpha ^t}r({s_t},{a_t})} |{s_0} = s) \equiv {E^{\pi ,s}}(\sum\limits_{t = 0}^\infty  {{\alpha ^t}r({s_t},{a_t})} )\]
+\[J_\alpha ^\pi (s) = {E^\pi }\left(\sum\limits_{t = 0}^\infty  {{\alpha ^t}r({s_t},{a_t})} |{s_0} = s\right) \equiv {E^{\pi ,s}}\left(\sum\limits_{t = 0}^\infty  {{\alpha ^t}r({s_t},{a_t})} \right)\]
 Here $0 < \alpha  < 1$ is the discount factor. Mathematically, the discount factor ensures convergence of the sum (whenever the reward sequence is bounded). This make the problem "well behaved", and relatively easy to analyze.
-\paragraph{Average return:}  Here we are interested to maximize the long-term average return. The most common definition of the long-term average return is
-\[J_{av}^\pi (s) = \mathop {\lim \inf }\limits_{T \to \infty } {E^{\pi ,s}}(\frac{1}{T}\sum\limits_{t = 0}^{T - 1} {r({s_t},{a_t})} )\]
+\paragraph{Average return:}  Here we are interested in maximizing the long-term average return. The most common definition of the long-term average return is
+\[J_{av}^\pi (s) = \mathop {\lim \inf }\limits_{T \to \infty } {E^{\pi ,s}}\left(\frac{1}{T}\sum\limits_{t = 0}^{T - 1} {r({s_t},{a_t})} \right)\]
 The theory of average-return planning problems is more involved, and relies to a larger extent on the theory of Markov chains.
 
 
@@ -259,7 +259,7 @@ In an important class of planning problems, the time horizon is not set beforeha
 Let  ${S_G} \subset S$ define the set of \emph{goal states}. Define
 \[\tau  = \inf \{ t \ge 0:{s_t} \in {S_G}\} \]
 as the first time in which a goal state is reached. The total expected return for this problem is defined as:
-\[J_{ssp}^\pi (s) = {E^{\pi ,s}}(\sum\limits_{t = 0}^{\tau  - 1} {r({s_t},{a_t})}  + {r_G}({s_\tau }))\]
+\[J_{ssp}^\pi (s) = {E^{\pi ,s}}\left(\sum\limits_{t = 0}^{\tau  - 1} {r({s_t},{a_t})}  + {r_G}({s_\tau })\right)\]
 Here ${r_G}(s),\;s \in {S_G}$ specified the reward at goal states.
 
 This class of problems provides a natural extension of the standard shortest-path problem to stochastic settings.  Some conditions on the system dynamics and reward function must be imposed for the problem to be well posed (e.g., that a goal state may be reached  with probability one).
@@ -296,7 +296,7 @@ The celebrated principle of optimality (stated by Bellman) applies to a large cl
 \end{center}
 
 This principle is not an actual claim, but rather a guiding principle that can be applied in different ways to each problem.
-For example, considering our finite-horizon problem, let ${\pi ^*} = ({\pi _0}, \ldots ,{\pi _{T - 1}})$ denote an optimal Markov policy. Take any state ${s_t} = s'$ which has a positive probability to be reached under ${\pi ^*}$, namely ${P^{\pi ,{s_0}}}({s_t} = s') > 0$. Then the tail policy $({\pi _t}, \ldots ,{\pi _{T - 1}})$ is optimal for the "tail" criterion $J_{t:T}^\pi (s') = {E^\pi }\left( {\sum\nolimits_{k = t}^T {{R_k}|{s_t} = s'} } \right)$.
+For example, considering our finite-horizon problem, let ${\pi ^*} = ({\pi _0}, \ldots ,{\pi _{T - 1}})$ denote an optimal Markov policy. Take any state ${s_t} = s'$ which has a positive probability to be reached under ${\pi ^*}$, namely ${P^{\pi^* ,{s_0}}}({s_t} = s') > 0$. Then the tail policy $({\pi _t}, \ldots ,{\pi _{T - 1}})$ is optimal for the "tail" criterion $J_{t:T}^\pi (s') = {E^\pi }\left( {\sum\nolimits_{k = t}^T {{R_k}|{s_t} = s'} } \right)$.
 
 
 \subsection{Dynamic Programming for Policy Evaluation}\label{sss:pol_eval}
@@ -307,7 +307,7 @@ Observe that $V_0^\pi ({s_0}) = {J^\pi }({s_0})$.
 
 \begin{lemma}[\textbf{Value Iteration}]\label{lem:finite_horizon_VI} $V_k^\pi (s)$ may be computed by the backward recursion:
 \[V_k^\pi (s) = {\left\{ {{r_k}(s,a) + \sum\nolimits_{s' \in {S_{k + 1}}} {{p_k}(s'|s,a)} \;V_{k + 1}^\pi (s')} \right\}_{a = {\pi _k}(s)}}\;,\quad s \in {S_k}\]
-for $k = T - 1, \ldots ,0$,  starting with  $V_T^\pi (s) = {r_T}(s)$.
+for $k = \{ T - 1, \ldots ,0 \}$,  starting with  $V_T^\pi (s) = {r_T}(s)$.
 \end{lemma}
 \begin{proof}
 Observe that:
@@ -396,7 +396,7 @@ Let ${\pi ^*}$ be the (Markov) policy defined in part 2 of Theorem \ref{thm:fini
 
 \subsection{The Q function}
 Let
-\[{Q_k}(s,a) \buildrel \Delta \over = {r_k}(s,a) + \sum\nolimits_{s' \in {S_k}} {{p_k}(s'|s,a)\,V_k^{}(s')} .\]
+\[{Q_k}(s,a) \buildrel \Delta \over = {r_k}(s,a) + \sum\nolimits_{s' \in {S_{k+1}}} {{p_k}(s'|s,a)\,V_{k+1}^{}(s')} .\]
 This is known as the optimal state-action value function, or simply as the \emph{Q-function}. ${Q_k}(s,a)$ is the expected return from stage $k$ onward, if we choose ${a_k} = a$  and then proceed optimally.
 
 Theorem \ref{thm:finite_horizon_DP} can now be succinctly expressed as

--- a/Lecture4.tex
+++ b/Lecture4.tex
@@ -19,7 +19,7 @@ The ${p_{ij}}$'s  are the transition probabilities, which satisfy
 ${p_{ij}} \ge 0,\;\;\;\sum\nolimits_{j \in X} {{p_{ij}} = 1\;\;\forall i} $.
 The matrix $P = ({p_{ij}})$ is the transition matrix.
 
-Given the initial distribution ${p_0}$ of ${X_0}$, namely $p({X_0} = i_0) = {p_0}(i_0)$, we obtain the finite-dimensional distributions:
+Given the initial distribution ${p_0}$ of ${X_0}$, namely $p({X_0} = i) = {p_0}(i)$, we obtain the finite-dimensional distributions:
 \[{\cal P}({X_0} = {i_0}, \ldots ,{X_t} = {i_t}) = {p_0}(i_0){p_{{i_0}{i_1}}} \cdot  \ldots  \cdot {p_{{i_{t - 1}}{i_t}}}.\]
 
 Define $p_{ij}^{(m)} = {\cal P}({X_m} = j|{X_0} = i),$ the m-step transition probabilities.  It is easy to verify that $p_{ij}^{(m)} = {[{P^m}]_{ij}}$  (here ${P^m}$ is the m-th power of the matrix $P$).
@@ -30,7 +30,7 @@ Define $p_{ij}^{(m)} = {\cal P}({X_m} = j|{X_0} = i),$ the m-step transition pro
 \item $i$ and $j$ are communicating states (or communicate) if $i \to j$ and $j \to i$.
 \item A communicating class (or just class) is a maximal collection of states that communicate.
 \item The Markov chain is irreducible if all states belong to a single class (i.e., all states communicate with each other).
-\item State $i$ is periodic with period $d \ge 2$ if  $p_{ii}^{(m)} = 0$ for $m \ne \ell d$ and  $p_{ii}^{(m)} > 0$ for $m = \ell d$, $\ell = \{ 1,2, \ldots \}$. Periodicity is a class property: all states in the same class have the same period.
+\item State $i$ is periodic with period $d \ge 2$ if  $p_{ii}^{(m)} = 0$ for $m \ne \ell d$ and  $p_{ii}^{(m)} > 0$ for $m = \ell d$, $\ell \in \{ 1,2, \ldots \}$. Periodicity is a class property: all states in the same class have the same period.
 \end{itemize}
 
 \paragraph{Recurrence:}
@@ -242,7 +242,7 @@ For $\lambda  > 0$, the exponent gives higher weight to high rewards, and the op
 \end{enumerate}
 
 \subsection{Infinite Horizon Problems}
-We next consider planning problems that extend to an unlimited time horizon, $t = \{0,1,2, \ldots \}$. Such planning problems arise when the system in question is expected to operate for a long time, or a large number of steps, possibly with no specific "closing" time.
+We next consider planning problems that extend to an unlimited time horizon, $t = 0,1,2, \ldots $. Such planning problems arise when the system in question is expected to operate for a long time, or a large number of steps, possibly with no specific "closing" time.
 Infinite horizon problems are most often defined for stationary problems. In that case, they enjoy the important advantage that optimal policies can be found among the class of stationary policies.  We will restrict attention here to stationary models.
 As before, we have the running reward function $r(s,a)$, which extends to all $t \ge 0$. The reward obtained at stage $t$ is  ${R_t} = r({s_t},{a_t})$.
 
@@ -307,7 +307,7 @@ Observe that $V_0^\pi ({s_0}) = {J^\pi }({s_0})$.
 
 \begin{lemma}[\textbf{Value Iteration}]\label{lem:finite_horizon_VI} $V_k^\pi (s)$ may be computed by the backward recursion:
 \[V_k^\pi (s) = {\left\{ {{r_k}(s,a) + \sum\nolimits_{s' \in {S_{k + 1}}} {{p_k}(s'|s,a)} \;V_{k + 1}^\pi (s')} \right\}_{a = {\pi _k}(s)}}\;,\quad s \in {S_k}\]
-for $k = \{ T - 1, \ldots ,0 \}$,  starting with  $V_T^\pi (s) = {r_T}(s)$.
+for $k =  T - 1, \ldots ,0 $,  starting with  $V_T^\pi (s) = {r_T}(s)$.
 \end{lemma}
 \begin{proof}
 Observe that:


### PR DESCRIPTION
1. line 2: involves -> involve, lecture -> chapter
2. line 19 (4.1 Markov Chains: Reminder): sum over i for all j -> sum of j for all i. since the each row sums to 1 in stochastic matrices
3. lines 22-23 (finite dimensional distribution): initial state i -> i₀
4. line 33 (State classification): missing brackets for integer 
5. line 56 (Ergodicity): notation consistency π(i) -> πᵢ
6. line 73 (Reversible Markov chains): changed i,j to ∀i,j
7. line 91 (Discrete-time-queue): changed i to ∀i
8. line 166: missing comma 
9. line 231 (Finite Horizon Problems - expected return value): resized brackets
10. line 232: maximized -> maximizes (tense)
11. line 236: added colon (consistency)
12. line 245 (time horizon): added missing brackets
13. line 250 (Discounted return): resized brackets
14. line 252 (Average return): to maximize -> in maximizing (tense)
15. line 253: resize brackets
16. line 262: resize brackets
17. line 299 (state probability): added * for optimal Markov policy
18. line 310 (Value Iteration): added brackets
19. line 399 (The Q function): fix time index k -> k + 1